### PR TITLE
Update FlexUnlimited.py

### DIFF
--- a/lib/FlexUnlimited.py
+++ b/lib/FlexUnlimited.py
@@ -178,7 +178,7 @@ class FlexUnlimited:
     offerStartHour = offer.expirationDate.hour
 
     if self.minBlockRate:
-      if self.minBlockRate > offer.blockRate:
+      if self.minBlockRate < offer.blockRate:
         return
 
     if self.arrivalBuffer:


### PR DESCRIPTION
On line 181, > was changed to <, because originally if self.minBlockRate > offer.Blockrate would reject offers that paid more than the minBlockRate.