### PR TITLE
Optional Pushover support

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,6 +10,8 @@
   "desiredWeekdays": ["MON", "tue", "Wed", "Thur", "Fri", "Sat", "Sunday"],
   "retryLimit": 10,
   "refreshInterval": 0.2,
+  "pushoverUserKey": "",
+  "pushoverApiKey": "ak4sd27iw28fazeoynabbikm93ju48",
   "twilioAcctSid": "",
   "twilioAuthToken": "",
   "twilioFromNumber": "",

--- a/lib/FlexUnlimited.py
+++ b/lib/FlexUnlimited.py
@@ -57,13 +57,13 @@ class FlexUnlimited:
     }
   }
   routes = {
-    "GetOffers": "https://flex-capacity-eu.amazon.com/GetOffersForProviderPost",
-    "AcceptOffer": "https://flex-capacity-eu.amazon.com/AcceptOffer",
+    "GetOffers": "https://flex-capacity-na.amazon.com/GetOffersForProviderPost",
+    "AcceptOffer": "https://flex-capacity-na.amazon.com/AcceptOffer",
     "GetAuthToken": "https://api.amazon.com/auth/register",
     "RequestNewAccessToken": "https://api.amazon.com/auth/token",
-    "ForfeitOffer": "https://flex-capacity-eu.amazon.com/schedule/blocks/",
-    "GetEligibleServiceAreas": "https://flex-capacity-eu.amazon.com/eligibleServiceAreas",
-    "GetOfferFiltersOptions": "https://flex-capacity-eu.amazon.com/getOfferFiltersOptions"
+    "ForfeitOffer": "https://flex-capacity-na.amazon.com/schedule/blocks/",
+    "GetEligibleServiceAreas": "https://flex-capacity-na.amazon.com/eligibleServiceAreas",
+    "GetOfferFiltersOptions": "https://flex-capacity-na.amazon.com/getOfferFiltersOptions"
   }
 
   def __init__(self) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ requests==2.28.1
 twilio==7.3.2
 urllib3==1.25.10
 wcwidth==0.2.5
+pushover-nythepegasus==1.0.1


### PR DESCRIPTION
An alternative over using twillo. I already use pushover for other things so it is my preferred way personally.

Like Twillo this is completely optional.

Pushover is an app that can receive push notifications via an API call. It is a premium service but not one that will break the bank at [$5 per device type for life](https://pushover.net/licensing) with 30 days free (so you could just make a new account each month). As stated I already use pushover for many other things so I added it for personal reasons but thought I'd commit it to the upstream if it is any use for anyone else.

The free tier for the API is 10k send a month so it should be fine for public use. You can create your own application if you want though.